### PR TITLE
chore: update site information for Clio-X Ecosystem

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -1,9 +1,9 @@
 {
-  "siteTitle": "Pontus-X Ecosystem - powered by Gaia-X",
-  "siteTagline": "Streamlined interoperability across digital service ecosystems.",
-  "siteUrl": "https://portal.pontus-x.eu",
+  "siteTitle": "Clio-X Cultural Heritage and Archives Ecosystem",
+  "siteTagline": "Building a sustainable and ethical future for digital archives and cultural heritage",
+  "siteUrl": "https://cliox.org",
   "siteImage": "/share.png",
-  "copyright": "All Rights Reserved. Powered by [Gaia-X](https://gaia-x.eu/), [Oasis](https://oasisprotocol.org/) and [Ocean Enterprise](https://www.oceanenterprise.io/). Built by [deltaDAO](https://delta-dao.com).",
+  "copyright": "All Rights Reserved Clio-X © 2025. Powered by [Gaia-X](https://gaia-x.eu/), [Oasis](https://oasisprotocol.org/) and [Ocean Enterprise](https://www.oceanenterprise.io/). Built by [deltaDAO](https://delta-dao.com).",
   "menu": [
     {
       "name": "Catalogue",


### PR DESCRIPTION
- Changed site title to "Clio-X Cultural Heritage and Archives Ecosystem"
- Updated site tagline to reflect focus on sustainable digital archives
- Modified site URL to point to the new Clio-X website
- Adjusted copyright notice for Clio-X