### PR TITLE
fix: display metadata NFT image in publish preview

### DIFF
--- a/src/components/Asset/AssetContent/Nft/index.tsx
+++ b/src/components/Asset/AssetContent/Nft/index.tsx
@@ -26,15 +26,13 @@ export default function Nft() {
     ? nftMetadata.image
     : formikState?.values?.metadata?.nft?.image_data
     ? formikState.values.metadata.nft.image_data
-    : null
+    : formikState?.values?.metadata?.nft?.image
+    ? formikState.values.metadata.nft.image
+    : '/images/cliox.svg' // Default ClioX logo when no NFT image is available
 
   return (
     <div className={styles.nftImage}>
-      {nftImage ? (
-        <img src={nftImage} alt={asset?.nft?.name} />
-      ) : (
-        <div className={styles.placeholder} />
-      )}
+      <img src={nftImage} alt={asset?.nft?.name || 'ClioX Logo'} />
 
       {(nftMetadata || asset?.nftAddress) && (
         <Tooltip


### PR DESCRIPTION
- Fix bug where NFT preview didn't match the image selected in metadata section
- Add missing fallback to formikState.values.metadata.nft.image property
- Ensure publish preview accurately reflects NFT image from section 1 of the Publish: Metadata
- Replace placeholder with ClioX logo when no custom NFT image is set