### PR TITLE
fix(ui): increase font size in network dropdown menu for better readability

### DIFF
--- a/src/components/Header/NetworkMenu/Details.module.css
+++ b/src/components/Header/NetworkMenu/Details.module.css
@@ -32,7 +32,7 @@
 .tokens button,
 .tokens button:hover {
   display: block;
-  font-size: var(--font-size-mini);
+  font-size: var(--font-size-small);
   margin-top: calc(var(--spacer) / 3);
   text-align: left;
 }


### PR DESCRIPTION
- Changed font-size from var(--font-size-mini) to var(--font-size-small) in NetworkMenu Details
- Improves readability of network names like "Pontus-X Devnet" in dropdown
- Font size increased from 0.65rem to 0.8125rem (~25% larger)