### PR TITLE
fix(vizhub): add comprehensive data cleanup on page exit

### DIFF
--- a/src/components/@shared/VizHub/VizHub.tsx
+++ b/src/components/@shared/VizHub/VizHub.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import SentimentChart from './visualizations/sentiment/SentimentChart'
 import DataDistribution from './visualizations/distribution/DataDistribution'
 import WordCloud from './visualizations/wordcloud'
@@ -7,7 +8,7 @@ import DocumentSummary from './visualizations/summary/DocumentSummary'
 import VisualizationWrapper from './ui/common/VisualizationWrapper'
 import LoadingIndicator from './ui/common/LoadingIndicator'
 import FutureFeatures from './ui/common/FutureFeatures'
-import { STORAGE_KEYS } from './store/dataStore'
+import { STORAGE_KEYS, useDataStore } from './store/dataStore'
 import { useVizHubData } from './hooks/useVizHubData'
 import { VizHubThemeProvider } from './store/themeStore'
 import type { VizHubProps, VizHubConfig } from './types'
@@ -76,6 +77,9 @@ function VizHubInternal({
     dataSourceInfo
   } = useVizHubData(data, config, useCaseConfig)
 
+  // Get the clearAllData function from the data store
+  const { clearAllData } = useDataStore()
+
   // Resolve component visibility with backward compatibility
   const componentVisibility = resolveComponentVisibility(effectiveConfig)
 
@@ -84,6 +88,14 @@ function VizHubInternal({
 
   // Get extensions
   const extensions = effectiveConfig.extensions || []
+
+  // Force clear data when component unmounts
+  useEffect(() => {
+    return () => {
+      // Clear all data when VizHub component is unmounted
+      clearAllData()
+    }
+  }, [clearAllData])
 
   // Show loading state if processing
   if (processingStatus === 'not_ready') {

--- a/src/pages/usecases/cameroonGazette.tsx
+++ b/src/pages/usecases/cameroonGazette.tsx
@@ -1,13 +1,27 @@
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 import Page from '@shared/Page'
 import { useRouter } from 'next/router'
 import content from '../../../content/pages/cameroonGazette.json'
 import TextAnalysis from '../../components/CameroonGazette'
+import { useDataStore } from '../../components/@shared/VizHub/store/dataStore'
+import { useUseCases } from '../../@context/UseCases'
 
 export default function CameroonGazette(): ReactElement {
   const router = useRouter()
+  const { clearAllData } = useDataStore()
+  const { clearTextAnalysis } = useUseCases()
 
   const { title, description } = content
+
+  // Clear both VizHub localStorage data and IndexedDB data when leaving the page
+  useEffect(() => {
+    return () => {
+      // Clear VizHub localStorage data
+      clearAllData()
+      // Clear IndexedDB TextAnalysis data
+      clearTextAnalysis()
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Page title={title} description={description} uri={router.route}>

--- a/src/pages/usecases/textAnalysis.tsx
+++ b/src/pages/usecases/textAnalysis.tsx
@@ -1,13 +1,27 @@
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 import Page from '@shared/Page'
 import { useRouter } from 'next/router'
 import content from '../../../content/pages/textAnalysis.json'
 import TextAnalysis from '../../components/TextAnalysis'
+import { useDataStore } from '../../components/@shared/VizHub/store/dataStore'
+import { useUseCases } from '../../@context/UseCases'
 
 export default function PageRoadDamage(): ReactElement {
   const router = useRouter()
+  const { clearAllData } = useDataStore()
+  const { clearTextAnalysis } = useUseCases()
 
   const { title, description } = content
+
+  // Clear both VizHub localStorage data and IndexedDB data when leaving the page
+  useEffect(() => {
+    return () => {
+      // Clear VizHub localStorage data
+      clearAllData()
+      // Clear IndexedDB TextAnalysis data
+      clearTextAnalysis()
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Page title={title} description={description} uri={router.route}>


### PR DESCRIPTION
- Clear both localStorage and IndexedDB data when leaving VizHub pages