### PR TITLE
SSR/Hydration fixes, controlled inputs, and SEO improvements

### DIFF
--- a/src/@context/UserPreferences.tsx
+++ b/src/@context/UserPreferences.tsx
@@ -12,6 +12,7 @@ import { useMarketMetadata } from './MarketMetadata'
 import { AUTOMATION_MODES } from './Automation/AutomationProvider'
 
 interface UserPreferencesValue {
+  prefsHydrated: boolean
   debug: boolean
   setDebug: (value: boolean) => void
   currency: string
@@ -66,6 +67,7 @@ function UserPreferencesProvider({
 }): ReactElement {
   const { appConfig } = useMarketMetadata()
   // Initialize with stable SSR-friendly defaults; hydrate from localStorage on mount
+  const [prefsHydrated, setPrefsHydrated] = useState<boolean>(false)
   const [debug, setDebug] = useState<boolean>(false)
   const [currency, setCurrency] = useState<string>('EUR')
   const [locale, setLocale] = useState<string>()
@@ -96,7 +98,10 @@ function UserPreferencesProvider({
   // Hydrate from localStorage on client after mount
   useEffect(() => {
     const stored = getLocalStorage()
-    if (!stored) return
+    if (!stored) {
+      setPrefsHydrated(true)
+      return
+    }
     if (typeof stored.debug === 'boolean') setDebug(stored.debug)
     if (typeof stored.currency === 'string') setCurrency(stored.currency)
     if (Array.isArray(stored.bookmarks)) setBookmarks(stored.bookmarks)
@@ -117,6 +122,7 @@ function UserPreferencesProvider({
       setShowOnboardingModule(stored.showOnboardingModule)
     if (typeof stored.onboardingStep === 'number')
       setOnboardingStep(stored.onboardingStep)
+    setPrefsHydrated(true)
   }, [])
 
   // Write values to localStorage on change
@@ -195,6 +201,7 @@ function UserPreferencesProvider({
     <UserPreferencesContext.Provider
       value={
         {
+          prefsHydrated,
           debug,
           currency,
           locale,

--- a/src/components/@shared/FormInput/InputElement/BoxSelection/index.tsx
+++ b/src/components/@shared/FormInput/InputElement/BoxSelection/index.tsx
@@ -37,8 +37,8 @@ export default function BoxSelection({
           <div key={option.name}>
             <input
               id={option.name}
-              defaultChecked={option.checked}
-              onChange={(event) => handleChange(event)}
+              checked={option.checked}
+              onChange={(event) => handleChange?.(event)}
               {...props}
               type="radio"
               className={styleClassesInput}

--- a/src/components/CameroonGazette/JobList.tsx
+++ b/src/components/CameroonGazette/JobList.tsx
@@ -21,7 +21,8 @@ export default function JobList(props: {
     cameroonGazetteData: CameroonGazetteUseCaseData[]
   ) => void
 }): ReactElement {
-  const { chainIds } = useUserPreferences()
+  const __DEV__ = process.env.NODE_ENV !== 'production'
+  const { chainIds, prefsHydrated } = useUserPreferences()
   const cameroonGazetteAlgoDids: string[] = Object.values(
     CAMEROON_GAZETTE_ALGO_DIDS
   )
@@ -120,8 +121,12 @@ export default function JobList(props: {
   ])
 
   useEffect(() => {
+    if (!prefsHydrated) return
     fetchJobs()
-  }, [refetchJobs, chainIds]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [refetchJobs, chainIds, prefsHydrated]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Log when accountId becomes available after cold refresh
+  useEffect(() => {}, [accountId])
 
   const addJobToView = async (job: ComputeJobMetaData) => {
     // If there's already an active job, remove it first
@@ -324,7 +329,7 @@ export default function JobList(props: {
       <Accordion title="Compute Jobs" defaultExpanded>
         <ComputeJobs
           jobs={jobs}
-          isLoading={isLoadingJobs}
+          isLoading={isLoadingJobs || !prefsHydrated}
           refetchJobs={() => setRefetchJobs(!refetchJobs)}
           getActions={getCustomActionsPerComputeJob}
           hideDetails

--- a/src/components/Header/NetworkMenu/index.tsx
+++ b/src/components/Header/NetworkMenu/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import Network from './Network'
 import Details from './Details'
 import Tooltip from '@shared/atoms/Tooltip'
@@ -7,12 +7,17 @@ import { useNetwork } from 'wagmi'
 
 export default function NetworkMenu(): ReactElement {
   const { chain } = useNetwork()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
 
-  return chain?.id ? (
+  // Defer rendering until after mount to avoid SSR/CSR mismatch
+  if (!mounted || !chain?.id) return null
+
+  return (
     <div className={styles.networkMenu}>
       <Tooltip content={<Details />} trigger="click focus mouseenter">
         <Network />
       </Tooltip>
     </div>
-  ) : null
+  )
 }

--- a/src/components/Header/UserPreferences/Debug.tsx
+++ b/src/components/Header/UserPreferences/Debug.tsx
@@ -12,7 +12,7 @@ export default function Debug(): ReactElement {
       name="debug"
       type="checkbox"
       options={['Activate Debug Mode']}
-      defaultChecked={debug === true}
+      checked={debug === true}
       onChange={() => setDebug(!debug)}
     />
   )

--- a/src/components/Header/UserPreferences/Networks/NetworkItem.tsx
+++ b/src/components/Header/UserPreferences/Networks/NetworkItem.tsx
@@ -33,7 +33,7 @@ export default function NetworkItem({
           name="chainIds"
           value={chainId}
           onChange={handleNetworkChanged}
-          defaultChecked={chainIds.includes(chainId)}
+          checked={chainIds.includes(chainId)}
         />
         <NetworkName key={chainId} networkId={chainId} />
       </label>

--- a/src/components/Privacy/CookieModule.tsx
+++ b/src/components/Privacy/CookieModule.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ReactElement, useEffect, useState } from 'react'
+import { ChangeEvent, ReactElement } from 'react'
 import { CookieConsentStatus, useConsent } from '@context/CookieConsent'
 import InputElement from '@shared/FormInput/InputElement'
 import Markdown from '@shared/Markdown'
@@ -13,14 +13,14 @@ export interface CookieModuleProps {
 export default function CookieModule(props: CookieModuleProps): ReactElement {
   const { cookieConsentStatus, setConsentStatus } = useConsent()
   const { title, desc, cookieName } = props
-  const [checked, setChecked] = useState<boolean>()
 
-  useEffect(() => {
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    const next = e.target.checked
     setConsentStatus(
       cookieName,
-      checked ? CookieConsentStatus.APPROVED : CookieConsentStatus.REJECTED
+      next ? CookieConsentStatus.APPROVED : CookieConsentStatus.REJECTED
     )
-  }, [checked])
+  }
 
   return (
     <div className={styles.wrapper}>
@@ -28,9 +28,7 @@ export default function CookieModule(props: CookieModuleProps): ReactElement {
         <InputElement
           type="checkbox"
           name={cookieName}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            setChecked(e.target.checked)
-          }}
+          onChange={handleChange}
           checked={
             cookieConsentStatus[cookieName] === CookieConsentStatus.APPROVED
           }

--- a/src/components/Privacy/PrivacyPreferenceCenter.tsx
+++ b/src/components/Privacy/PrivacyPreferenceCenter.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useConsent, CookieConsentStatus } from '@context/CookieConsent'
 import styles from './PrivacyPreferenceCenter.module.css'
 import { useGdprMetadata } from '@hooks/useGdprMetadata'
@@ -19,6 +19,10 @@ export default function CookieBanner({
   const cookies = useGdprMetadata()
   const { showPPC, setShowPPC } = useUserPreferences()
   const [smallBanner, setSmallBanner] = useState<boolean>(style === 'small')
+  const [mounted, setMounted] = useState(false)
+
+  // Avoid SSR/CSR flash by deferring render until mounted
+  useEffect(() => setMounted(true), [])
 
   function closeBanner() {
     setShowPPC(false)
@@ -40,6 +44,8 @@ export default function CookieBanner({
     hidden: !showPPC,
     small: smallBanner // style === 'small'
   })
+
+  if (!mounted) return null
 
   return (
     <div className={styleClasses}>

--- a/src/components/Profile/History/ComputeJobs/index.tsx
+++ b/src/components/Profile/History/ComputeJobs/index.tsx
@@ -75,6 +75,12 @@ export default function ComputeJobs({
   const { address: accountId } = useAccount()
   const { chainIds } = useUserPreferences()
 
+  // Ensure consistent SSR/CSR markup to avoid hydration mismatch
+  const [isClient, setIsClient] = useState(false)
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
   const [actionsColumn, setActionsColumn] =
     useState<TableOceanColumn<ComputeJobMetaData>>(defaultActionsColumn)
 
@@ -100,6 +106,11 @@ export default function ComputeJobs({
       )
     })
   }, [getActions])
+
+  if (!isClient) {
+    // Render a stable placeholder on server and before client mount
+    return <div />
+  }
 
   return accountId ? (
     <>

--- a/src/components/Profile/History/index.tsx
+++ b/src/components/Profile/History/index.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
 import Tabs from '@shared/atoms/Tabs'
 import PublishedList from './PublishedList'
 import Downloads from './Downloads'
@@ -65,6 +66,7 @@ export default function HistoryPage({
 }: {
   accountIdentifier: string
 }): ReactElement {
+  const router = useRouter()
   const { address: accountId } = useAccount()
   const { autoWallet } = useAutomation()
   const { chainIds } = useUserPreferences()
@@ -123,8 +125,15 @@ export default function HistoryPage({
   }, [accountId, refetchJobs, fetchJobs])
 
   const getDefaultIndex = useCallback((): number => {
-    const url = new URL(location.href)
-    const defaultTabString = url.searchParams.get('defaultTab')
+    // Prefer router.asPath for SSR-safety; fall back to window on client
+    const search =
+      typeof window !== 'undefined'
+        ? window.location.search
+        : router?.asPath?.includes('?')
+        ? `?${router.asPath.split('?')[1]}`
+        : ''
+    const params = new URLSearchParams(search)
+    const defaultTabString = params.get('defaultTab')
     const defaultTabIndex = tabsIndexList?.[defaultTabString]
 
     if (!defaultTabIndex) return 0
@@ -135,7 +144,7 @@ export default function HistoryPage({
       return 0
 
     return defaultTabIndex
-  }, [accountId, accountIdentifier])
+  }, [accountId, accountIdentifier, router?.asPath])
 
   useEffect(() => {
     setTabIndex(getDefaultIndex())

--- a/src/components/Resources/index.tsx
+++ b/src/components/Resources/index.tsx
@@ -50,6 +50,9 @@ interface ResourcesProps {
 export default function Resources({
   initialArticles = []
 }: ResourcesProps): ReactElement {
+  // useLayoutEffect doesn't run on the server; fall back to useEffect to avoid hydration warnings
+  const useIsomorphicLayoutEffect =
+    typeof window !== 'undefined' ? useLayoutEffect : useEffect
   const [activeTab, setActiveTab] = useState('articles')
   const [searchQuery, setSearchQuery] = useState('')
   const [resourceCards, setResourceCards] =
@@ -155,7 +158,7 @@ export default function Resources({
   }, [activeTab, initialArticles])
 
   // Recalculate underline when active tab or layout changes
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (searchQuery.trim() !== '') return
     // Measure synchronously before paint to avoid initial slide-in
     updateUnderline()

--- a/src/components/Search/Filter.tsx
+++ b/src/components/Search/Filter.tsx
@@ -92,13 +92,13 @@ export default function Filter({
 
   const router = useRouter()
 
-  const parsedUrl = queryString.parse(location.search, {
-    arrayFormat: 'separator'
-  })
-
   useEffect(() => {
-    const initialFilters = getInitialFilters(parsedUrl, Object.keys(filters))
+    const initialFilters = getInitialFilters(
+      router.query as unknown as queryString.ParsedQuery<string>,
+      Object.keys(filters)
+    )
     setFilters(initialFilters)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function applyFilter(filter: string[], filterId: string) {

--- a/src/components/Search/sort.tsx
+++ b/src/components/Search/sort.tsx
@@ -44,16 +44,13 @@ export default function Sort({
 
   const router = useRouter()
 
-  const parsedUrl = queryString.parse(location.search, {
-    arrayFormat: 'separator'
-  })
-
   useEffect(() => {
     const initialFilters = getInitialFilters(
-      parsedUrl,
+      router.query as unknown as queryString.ParsedQuery<string>,
       Object.keys(sort) as (keyof SortInterface)[]
     )
     setSort(initialFilters)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function sortResults(

--- a/src/components/TextAnalysis/JobList.tsx
+++ b/src/components/TextAnalysis/JobList.tsx
@@ -19,7 +19,8 @@ import { TextAnalysisResult } from './_types'
 export default function JobList(props: {
   setTextAnalysisData: (textAnalysisData: TextAnalysisUseCaseData[]) => void
 }): ReactElement {
-  const { chainIds } = useUserPreferences()
+  const __DEV__ = process.env.NODE_ENV !== 'production'
+  const { chainIds, prefsHydrated } = useUserPreferences()
   const textAnalysisAlgoDids: string[] = Object.values(TEXT_ANALYSIS_ALGO_DIDS)
 
   const { address: accountId } = useAccount()
@@ -113,8 +114,12 @@ export default function JobList(props: {
   ])
 
   useEffect(() => {
+    if (!prefsHydrated) return
     fetchJobs()
-  }, [refetchJobs, chainIds]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [refetchJobs, chainIds, prefsHydrated]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Log when accountId becomes available after cold refresh
+  useEffect(() => {}, [accountId])
 
   const addJobToView = async (job: ComputeJobMetaData) => {
     // If there's already an active job, remove it first
@@ -314,7 +319,7 @@ export default function JobList(props: {
       <Accordion title="Compute Jobs" defaultExpanded>
         <ComputeJobs
           jobs={jobs}
-          isLoading={isLoadingJobs}
+          isLoading={isLoadingJobs || !prefsHydrated}
           refetchJobs={() => setRefetchJobs(!refetchJobs)}
           getActions={getCustomActionsPerComputeJob}
           hideDetails

--- a/src/components/Verify/index.tsx
+++ b/src/components/Verify/index.tsx
@@ -44,11 +44,11 @@ export default function VerifyPage({
   const { label, placeholder, buttonLabel } = input
 
   const [isLoading, setIsLoading] = useState(false)
-  const [did, setDid] = useState<string>()
+  const [did, setDid] = useState<string>('')
   const [serviceCredential, setServiceCredential] = useState<string>()
 
-  const getDidString = (did: string): string => {
-    if (!did) return
+  const getDidString = (did?: string): string => {
+    if (!did) return ''
     return did.startsWith('did:op:') ? did : `did:op:${did}`
   }
 
@@ -113,7 +113,7 @@ export default function VerifyPage({
               setDid((event.target as HTMLInputElement).value)
             }
             placeholder={placeholder}
-            value={did}
+            value={did ?? ''}
           />
           <Button
             disabled={!did || isLoading}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -19,7 +19,7 @@ export default function Page404(): ReactElement {
       <Page
         title="404 - Page Not Found"
         description="The page you are looking for might have been removed, had its name changed, or is temporarily unavailable."
-        uri={router.route}
+        uri={router.pathname}
         headerCenter
         noPageHeader
       >

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/src/pages/bookmarks.tsx
+++ b/src/pages/bookmarks.tsx
@@ -1,14 +1,15 @@
 import { ReactElement } from 'react'
 import Page from '@shared/Page'
-import router from 'next/router'
+import { useRouter } from 'next/router'
 import Bookmarks from '@components/Home/Bookmarks'
 import content from '../../content/pages/bookmarks.json'
 
 export default function PageHome(): ReactElement {
+  const router = useRouter()
   const { title, description } = content
 
   return (
-    <Page title={title} description={description} uri={router.route}>
+    <Page title={title} description={description} uri={router.pathname}>
       <Bookmarks />
     </Page>
   )

--- a/src/pages/coming-soon.tsx
+++ b/src/pages/coming-soon.tsx
@@ -19,7 +19,7 @@ export default function ComingSoon(): ReactElement {
       <Page
         title="Coming Soon"
         description="This feature is currently under development and will be available soon."
-        uri={router.route}
+        uri={router.pathname}
         headerCenter
         noPageHeader
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ export default function PageHome(): ReactElement {
     <Page
       title={siteContent?.siteTitle}
       description={siteContent?.siteTagline}
-      uri={router.route}
+      uri={router.pathname}
       noContainer
       headerCenter
     >

--- a/src/pages/intake.tsx
+++ b/src/pages/intake.tsx
@@ -11,7 +11,7 @@ export default function IntakePage(): ReactElement {
     <Page
       title="Partner Intake Form"
       description="Join the Clio-X community as a partner organization"
-      uri={router.route}
+      uri={router.pathname}
       noPageHeader
     >
       <Container>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -43,7 +43,7 @@ export default function PageProfile(): ReactElement {
 
   return (
     <Page
-      uri={router.route}
+      uri={router.pathname}
       title={accountTruncate(finalAccountId)}
       noPageHeader
     >

--- a/src/pages/publish/[step].tsx
+++ b/src/pages/publish/[step].tsx
@@ -2,16 +2,17 @@ import { ReactElement } from 'react'
 import Publish from '../../components/Publish'
 import Page from '@shared/Page'
 import content from '../../../content/publish/index.json'
-import router from 'next/router'
+import { useRouter } from 'next/router'
 
 export default function PagePublish(): ReactElement {
+  const router = useRouter()
   const { title, description } = content
 
   return (
     <Page
       title={title}
       description={description}
-      uri={router.route}
+      uri={router.pathname}
       noPageHeader
     >
       <Publish content={content} />

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -13,7 +13,7 @@ export default function PageResources(): ReactElement {
     <Page
       title="Resources - The Reading Room"
       description="Your go-to hub for valuable resources and everything you need to get the most out of Clio-X."
-      uri={router.route}
+      uri={router.pathname}
       noPageHeader
     >
       <Resources initialArticles={articlesIndex.articles} />

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -48,7 +48,7 @@ export default function PageSearch(): ReactElement {
           ? '**Results displayed are limited to the first 10k, please refine your search.**'
           : undefined
       }
-      uri={router.route}
+      uri={router.pathname}
     >
       <Search
         setTotalResults={setTotalResults}

--- a/src/pages/usecases/cameroonGazette.tsx
+++ b/src/pages/usecases/cameroonGazette.tsx
@@ -24,7 +24,7 @@ export default function CameroonGazettePage(): ReactElement {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <Page title={title} description={description} uri={router.route}>
+    <Page title={title} description={description} uri={router.pathname}>
       <CameroonGazette />
     </Page>
   )

--- a/src/pages/usecases/chatbotCameroon.tsx
+++ b/src/pages/usecases/chatbotCameroon.tsx
@@ -26,7 +26,7 @@ export default function PageChatbotCameroon(): ReactElement {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <Page title={title} description={description} uri={router.route}>
+    <Page title={title} description={description} uri={router.pathname}>
       <ChatbotCameroon />
     </Page>
   )

--- a/src/pages/usecases/chatbotIris.tsx
+++ b/src/pages/usecases/chatbotIris.tsx
@@ -26,7 +26,7 @@ export default function PageChatbotIris(): ReactElement {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <Page title={title} description={description} uri={router.route}>
+    <Page title={title} description={description} uri={router.pathname}>
       <ChatbotIris />
     </Page>
   )

--- a/src/pages/usecases/textAnalysis.tsx
+++ b/src/pages/usecases/textAnalysis.tsx
@@ -24,7 +24,7 @@ export default function TextAnalysisPage(): ReactElement {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <Page title={title} description={description} uri={router.route}>
+    <Page title={title} description={description} uri={router.pathname}>
       <TextAnalysis />
     </Page>
   )

--- a/src/pages/verify.tsx
+++ b/src/pages/verify.tsx
@@ -14,7 +14,7 @@ export default function PageVerify(): ReactElement {
       <Page
         title={content.title}
         description={content.description}
-        uri={router.route}
+        uri={router.pathname}
       >
         <Verify didQueryString={did as string} />
       </Page>


### PR DESCRIPTION
## Overview
This PR focuses on improving SSR/CSR consistency (removing hydration warnings and flashes), converting several inputs to controlled components, and tightening SEO/analytics integration using Next.js best practices.

## Changes by theme
- SSR/Hydration
  - `src/@context/UrqlProvider.tsx`: Initialize URQL client synchronously using `getOceanConfig(1)`. If `subgraphUri` is missing, skip provider initialization and surface an error via `getUrqlClientInstance()` to expose misconfiguration early.
  - `src/components/Header/NetworkMenu/index.tsx`: Add `mounted` guard to avoid SSR/CSR mismatch.
  - `src/components/Privacy/PrivacyPreferenceCenter.tsx`: Defer rendering until mounted to prevent initial flash.
  - `src/components/Resources/index.tsx`: Introduce an isomorphic layout effect (use `useLayoutEffect` on client, fallback to `useEffect` on server) to avoid hydration warnings.
  - `src/components/Profile/History/index.tsx`: Use `router.asPath`/`window.location.search` when reading query params for SSR safety.

- Controlled inputs
  - `src/components/@shared/FormInput/InputElement/BoxSelection/index.tsx`: Switch from `defaultChecked` to `checked`, call `handleChange` safely.
  - `src/components/Header/UserPreferences/Networks/NetworkItem.tsx`: Use `checked` instead of `defaultChecked`.
  - `src/components/Header/UserPreferences/Debug.tsx`: Use controlled `checked`.
  - `src/components/Privacy/CookieModule.tsx`: Remove intermediate state/effect, update consent status directly in `onChange`.

- SEO & Analytics
  - `src/components/@shared/Page/Seo/index.tsx`: Stop relying on `window` at render time; derive `noindex` from hostname parsed from `siteUrl` (only add `twitter:creator` on production). Load Plausible via `next/script` (`strategy="afterInteractive"`). `Html lang` is moved to `_document`.
  - `src/pages/_document.tsx`: New custom Document with `<Html lang="en">`.

- Page `uri` and routing
  - Replace `uri={router.route}` with `uri={router.pathname}` across pages and use `useRouter` import.

- Search filter/sort initialization
  - `src/components/Search/Filter.tsx` and `src/components/Search/sort.tsx`: Initialize from `router.query` instead of `location.search` for SSR safety.

## Affected files
- `src/@context/UrqlProvider.tsx`
- `src/@context/UserPreferences.tsx`
- `src/components/@shared/FormInput/InputElement/BoxSelection/index.tsx`
- `src/components/@shared/Page/Seo/index.tsx`
- `src/components/Header/NetworkMenu/index.tsx`
- `src/components/Header/UserPreferences/Debug.tsx`
- `src/components/Header/UserPreferences/Networks/NetworkItem.tsx`
- `src/components/Privacy/CookieModule.tsx`
- `src/components/Privacy/PrivacyPreferenceCenter.tsx`
- `src/components/Profile/History/index.tsx`
- `src/components/Resources/index.tsx`
- `src/components/Search/Filter.tsx`
- `src/components/Search/sort.tsx`
- `src/pages/_document.tsx` (new)
- Multiple `src/pages/*.tsx` files (use `router.pathname` for `uri`)