### PR TITLE
feat(public-relations): add new public relations resources and documentation

### DIFF
--- a/content/resources/research/public-relations.json
+++ b/content/resources/research/public-relations.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "linkedin:guCHmimK",
+    "title": "Explore the Clio-X Resources Hub and Events Map",
+    "authors": ["Clio-X.org"],
+    "year": 2025,
+    "link": "https://lnkd.in/p/guCHmimK",
+    "group": "public-relations",
+    "topic": "public-relations",
+    "abstract": "Discover our Resources Hub—including the Events Map—featuring upcoming Clio-X engagements: July 7–19, 2025 Blockchain@UBC Summer Institute (Vancouver), August 27, 2025 Archives and Records Association UK Annual Conference (Bristol), and October 27, 2025 International Archives Congress (Barcelona)."
+  },
+  {
+    "id": "linkedin:gZAYeUa9",
+    "title": "Clio-X Congratulates Dr. Esther Olembe on French National Order of Merit",
+    "authors": ["Clio-X.org"],
+    "year": 2025,
+    "link": "https://lnkd.in/p/gZAYeUa9",
+    "group": "public-relations",
+    "topic": "public-relations",
+    "abstract": "Recognition of Dr. Esther Olembe, Director of the National Archives of Cameroon, elevated to Chevalier (Knight) of the French National Order of Merit—honoring her leadership in archival diplomacy, scientific knowledge promotion, and international cooperation."
+  },
+  {
+    "id": "linkedin:g6vvpzrj",
+    "title": "National Archives of Cameroon and Project Clio-X Announce Privacy-First AI Archival Collaboration",
+    "authors": ["Clio-X.org"],
+    "year": 2025,
+    "link": "https://lnkd.in/p/g6vvpzrj",
+    "group": "public-relations",
+    "topic": "public-relations",
+    "abstract": "Announcement of a strategic partnership between the National Archives of Cameroon and Project Clio-X to build a privacy-first AI archival platform; full press release available via the linked article."
+  }
+]

--- a/docs/research-public-relations-json.md
+++ b/docs/research-public-relations-json.md
@@ -1,0 +1,14 @@
+Research – Public Relations JSON Instructions
+
+Location: content/resources/research/public-relations.json
+
+Shape: JSON array of objects matching ResearchPaper with fields: id (string), title (string), authors (string array), year (number), link (string), group (string: public-relations), topic (string: public-relations), abstract (optional string), doi (optional string, unused).
+
+Example item:
+{ "id": "linkedin:urn:li:activity:123", "title": "Clio-X joins XYZ initiative", "authors": ["Clio-X"], "year": 2025, "link": "https://www.linkedin.com/posts/clio-x-org_123/", "group": "public-relations", "topic": "public-relations", "abstract": "Announcement of our partnership with XYZ." }
+
+Script guidelines: set group and topic to public-relations; de-duplicate by link; keep newest first; English-only title/abstract; keep 20-50 items.
+
+Validation: id non-empty; title non-empty; authors non-empty; year is 4-digit; link https; group/topic equal to public-relations.
+
+Workflow: run Python to fetch posts; map to this schema; overwrite the JSON file; commit and verify in Resources → Research → Public Relations.

--- a/src/components/Resources/Research.tsx
+++ b/src/components/Resources/Research.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useState, useMemo } from 'react'
 import { motion } from 'motion/react'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline'
+import { IconBrandLinkedin } from '@tabler/icons-react'
 import { ResearchSortBy, ResearchGroup } from './types'
 import {
   getResearchTopics,
@@ -183,14 +184,44 @@ export default function Research(): ReactElement {
                 <ul className="space-y-4">
                   {topic.papers.map((paper) => (
                     <li key={paper.id} className="text-base">
-                      <a
-                        href={paper.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-gray-900 hover:text-amber-700 hover:underline transition-colors duration-200 leading-relaxed"
-                      >
-                        {paper.authors.join(', ')} ({paper.year}). {paper.title}
-                      </a>
+                      {topic.id === 'public-relations' ? (
+                        <a
+                          href={paper.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="group flex w-full items-start gap-2 text-gray-900 hover:text-amber-700 transition-colors duration-200"
+                        >
+                          {/* Left icon */}
+                          <IconBrandLinkedin
+                            size={16}
+                            className="text-amber-700 opacity-80 group-hover:opacity-100 self-start mt-[3px]"
+                            aria-hidden="true"
+                          />
+
+                          {/* Title + year inline. External icon drawn via ::after to stay at end of last line */}
+                          <span
+                            className="min-w-0 flex-1 leading-snug underline-offset-2 group-hover:underline after:ml-1 after:content-['↗'] after:text-gray-400 group-hover:after:text-amber-700"
+                            aria-label={paper.title}
+                          >
+                            <span className="text-sm md:text-base">
+                              {paper.title}
+                            </span>{' '}
+                            <span className="text-xs text-gray-400 group-hover:text-amber-700">
+                              {paper.year}
+                            </span>
+                          </span>
+                        </a>
+                      ) : (
+                        <a
+                          href={paper.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-gray-900 hover:text-amber-700 hover:underline transition-colors duration-200 leading-relaxed"
+                        >
+                          {paper.authors.join(', ')} ({paper.year}).{' '}
+                          {paper.title}
+                        </a>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/src/utils/loadResearch.ts
+++ b/src/utils/loadResearch.ts
@@ -4,9 +4,10 @@ import {
   ResearchSortBy,
   ResearchGroup
 } from '@/components/Resources/types'
+import prPublicRelations from '../../content/resources/research/public-relations.json'
 
-// Research papers data
-const researchPapers: ResearchPaper[] = [
+// Research papers data (base)
+const baseResearchPapers: ResearchPaper[] = [
   {
     id: 'cameron-2025-navigating',
     title:
@@ -59,6 +60,19 @@ const researchPapers: ResearchPaper[] = [
   }
 ]
 
+// Public Relations posts, modeled as ResearchPaper entries
+const prPapers: ResearchPaper[] = (prPublicRelations as ResearchPaper[]).map(
+  (item) => ({
+    ...item,
+    // Enforce required grouping/topic to align with UI filters
+    group: 'public-relations',
+    topic: 'public-relations'
+  })
+)
+
+// Combined research papers list
+const researchPapers: ResearchPaper[] = [...baseResearchPapers, ...prPapers]
+
 // Research topics configuration
 const researchTopics: ResearchTopic[] = [
   {
@@ -80,8 +94,7 @@ const researchTopics: ResearchTopic[] = [
   {
     id: 'public-relations',
     title: 'Public Relations',
-    papers: [],
-    comingSoon: true
+    papers: researchPapers.filter((paper) => paper.topic === 'public-relations')
   }
 ]
 


### PR DESCRIPTION
- Introduced a new JSON file containing public relations research resources, including details on events and recognitions.
- Created accompanying documentation for the public relations JSON structure and guidelines for data entry.
- Updated the Research component to display public relations papers with enhanced UI elements, including LinkedIn icons for better visibility.